### PR TITLE
Issue 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 Searchio! workflow for Alfred
-=============================
+==============================
 
 Auto-suggest search results from multiple search engines and languages.
 


### PR DESCRIPTION
_Apologies for submitting an issue in this format, I think the issues tab is turned off._ 

**Problem** 
Exits with code 137 upon running in macOS 13. Unsure what's causing this.

**Relevant issues**
Identical problem happens with un-ported version of Searchio: deanishe/alfred-searchio#70

This problem is unlikely to be directly relevant to your python3 porting efforts, but thought I'd raise it since it renders searchio unusable anyway from macOS 13 onwards. 

